### PR TITLE
Fix: upCmd passes all args without parsing any flag

### DIFF
--- a/pkg/commands/up.go
+++ b/pkg/commands/up.go
@@ -1,8 +1,9 @@
 package commands
 
 import (
-	"github.com/h8r-dev/heighliner/pkg/clientcmd/util"
 	"github.com/spf13/cobra"
+
+	"github.com/h8r-dev/heighliner/pkg/clientcmd/util"
 )
 
 var (


### PR DESCRIPTION
#45 