### PR TITLE
ci: add permission to release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
The homebrew tap repo needs it